### PR TITLE
PVP stats balance first update

### DIFF
--- a/resources/data/Multiplayer/attacks.json
+++ b/resources/data/Multiplayer/attacks.json
@@ -1,0 +1,217 @@
+[
+	{
+		"Name": "Slash",
+		"DamageType": "Normal",
+		"DamageElement": "Normal",
+		"BaseDamage": 5,
+		"ScalingType": "Sword",
+		"ScalingAmount": 1,
+		"Force": 0.5,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentSimpleEnemyHit"
+	},
+	{
+		"Name": "ComboNormal",
+		"DamageType": "Normal",
+		"DamageElement": "Normal",
+		"BaseDamage": 15,
+		"ScalingType": "Sword",
+		"ScalingAmount": 3,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "ComboUp",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 25,
+		"ScalingType": "Sword",
+		"ScalingAmount": 5,
+		"Force": 0.1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "ComboDown",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 20,
+		"ScalingType": "Sword",
+		"ScalingAmount": 4,
+		"Force": 0,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "Charged",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 12.5,
+		"ScalingType": "Sword",
+		"ScalingAmount": 2.5,
+		"Force": 2,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "Lunge",
+		"DamageType": "Normal",
+		"DamageElement": "Normal",
+		"BaseDamage": 10,
+		"ScalingType": "Sword",
+		"ScalingAmount": 2,
+		"Force": 3,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentLungeAttackHit"
+	},
+	{
+		"Name": "Vertical",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 15,
+		"ScalingType": "Sword",
+		"ScalingAmount": 3,
+		"Force": 0,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "Ranged",
+		"DamageType": "Normal",
+		"DamageElement": "Fire",
+		"BaseDamage": 9.5,
+		"ScalingType": "Blood",
+		"ScalingAmount": 1.5,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Attack/PenitentRangeAttackHit"
+	},
+	{
+		"Name": "ChargedProjectile",
+		"DamageType": "Normal",
+		"DamageElement": "Normal",
+		"BaseDamage": 12.5,
+		"ScalingType": "Sword",
+		"ScalingAmount": 2.5,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Attack/PenitentChargedAttackProjectileHit"
+	},
+	{
+		"Name": "RangedExplosion",
+		"DamageType": "Heavy",
+		"DamageElement": "Fire",
+		"BaseDamage": 15.2,
+		"ScalingType": "Blood",
+		"ScalingAmount": 2.4,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentAcolyteDamage"
+	},
+	{
+		"Name": "Gem",
+		"DamageType": "Normal",
+		"DamageElement": "Lightning",
+		"BaseDamage": 3.75,
+		"ScalingType": "Sword",
+		"ScalingAmount": 0.75,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentMagicDamage"
+	},
+	{
+		"Name": "PrayerHit",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 15,
+		"ScalingType": "Sword",
+		"ScalingAmount": 3,
+		"Force": 0,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentHeavyEnemyHit"
+	},
+	{
+		"Name": "Debla",
+		"DamageType": "Normal",
+		"DamageElement": "Magic",
+		"BaseDamage": 30,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 15,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentMagicDamage"
+	},
+	{
+		"Name": "Taranto",
+		"DamageType": "Heavy",
+		"DamageElement": "Lightning",
+		"BaseDamage": 12,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 12,
+		"Force": 0,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentMagicDamage"
+	},
+	{
+		"Name": "Verdiales",
+		"DamageType": "Normal",
+		"DamageElement": "Fire",
+		"BaseDamage": 20,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 20,
+		"Force": 2,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentWaxcrawlerDamage"
+	},
+	{
+		"Name": "Lorquiana",
+		"DamageType": "Normal",
+		"DamageElement": "Lightning",
+		"BaseDamage": 25,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 8.75,
+		"Force": 0
+	},
+	{
+		"Name": "Tirana",
+		"DamageType": "Normal",
+		"DamageElement": "Lightning",
+		"BaseDamage": 30,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 30,
+		"Force": 1,
+		"SoundId": "event:/SFX/Penitent/Damage/PenitentMagicDamage"
+	},
+	{
+		"Name": "PoisonMist",
+		"DamageType": "Normal",
+		"DamageElement": "Toxic",
+		"BaseDamage": 25,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 18.75,
+		"Force": 0
+	},
+	{
+		"Name": "Shield",
+		"DamageType": "Normal",
+		"DamageElement": "Magic",
+		"BaseDamage": 15,
+		"ScalingType": "Prayer",
+		"ScalingAmount": 15,
+		"Force": 1.5,
+		"SoundId": "event:/SFX/Penitent/Attack/PenitentRangeAttackHit"
+	},
+	{
+		"Name": "Miriam",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 40,
+		"ScalingType": "Sword",
+		"ScalingAmount": 1,
+		"Force": 2
+	},
+	{
+		"Name": "MiriamSpike",
+		"DamageType": "Normal",
+		"DamageElement": "Normal",
+		"BaseDamage": 16,
+		"ScalingType": "Sword",
+		"ScalingAmount": 0.4,
+		"Force": 0
+	},
+	{
+		"Name": "Aubade",
+		"DamageType": "Heavy",
+		"DamageElement": "Normal",
+		"BaseDamage": 60,
+		"ScalingType": "Sword",
+		"ScalingAmount": 2,
+		"Force": 4.444
+	}
+]

--- a/resources/data/Multiplayer/defenses.json
+++ b/resources/data/Multiplayer/defenses.json
@@ -1,0 +1,86 @@
+[
+    {
+        "id": "RB01",
+        "physicalReduction": 0.05
+    },
+    {
+        "id": "RB02",
+        "physicalReduction": 0.1
+    },
+    {
+        "id": "RB03",
+        "physicalReduction": 0.15
+    },
+    {
+        "id": "RB08",
+        "fireReduction": 0.25
+    },
+    {
+        "id": "RB11",
+        "fireReduction": 0.35
+    },
+    {
+        "id": "RB09",
+        "toxicReduction": 0.25
+    },
+    {
+        "id": "RB12",
+        "toxicReduction": 0.35
+    },
+    {
+        "id": "RB13",
+        "lightningReduction": 0.25
+    },
+    {
+        "id": "RB31",
+        "lightningReduction": 0.35
+    },
+    {
+        "id": "RB32",
+        "magicReduction": 0.25
+    },
+    {
+        "id": "RB33",
+        "magicReduction": 0.35
+    },
+    {
+        "id": "RB10",
+        "condition": "LowHealth",
+        "physicalReduction": 0.5,
+        "magicReduction": 0.5,
+        "lightningReduction": 0.5,
+        "fireReduction": 0.5,
+        "toxicReduction": 0.5
+    },
+    {
+        "id": "RB201",
+        "condition": "NoFlasks",
+        "physicalReduction": 0.2,
+        "magicReduction": 0.2,
+        "lightningReduction": 0.2,
+        "fireReduction": 0.2,
+        "toxicReduction": 0.2
+    },
+    {
+        "id": "RB36",
+        "magicReduction": 0.1,
+        "lightningReduction": 0.1,
+        "fireReduction": 0.1,
+        "toxicReduction": 0.1
+    },
+    {
+        "id": "HE10",
+        "magicReduction": -0.5,
+        "lightningReduction": -0.5,
+        "fireReduction": -0.5,
+        "toxicReduction": -0.5
+    },
+    {
+        "id": "HE04",
+        "physicalReduction": -0.5
+    },
+    {
+        "id": "HE101",
+        "physicalReduction": -0.5
+    }
+]

--- a/resources/data/Multiplayer/offenses.json
+++ b/resources/data/Multiplayer/offenses.json
@@ -1,0 +1,42 @@
+[
+    {
+        "id": "RB06",
+        "swordIncrease": 2.5
+    },
+    {
+        "id": "RB104",
+        "condition": "NoFlasks",
+        "swordIncrease": 5
+    },
+    {
+        "id": "RB30",
+        "prayerIncrease": 0.8
+    },
+    {
+        "id": "HE01",
+        "prayerIncrease": 1.2,
+        "bloodIncrease": 8
+    },
+    {
+        "id": "HE03",
+        "condition": "LowHealth",
+        "swordIncrease": 15
+    },
+    {
+        "id": "HE04",
+        "swordIncrease": 10
+    },
+    {
+        "id": "HE05",
+        "bloodIncrease": -6.5
+    },
+    {
+        "id": "HE201",
+        "swordIncrease": 3
+    },
+    {
+        "id": "PR10",
+        "swordIncrease": 10
+    }
+
+]

--- a/resources/data/Multiplayer/pvp_patch_notes.txt
+++ b/resources/data/Multiplayer/pvp_patch_notes.txt
@@ -1,0 +1,39 @@
+2024-04-29:
+
+Attacks:
+🟩[buff] rising combo finisher damage 4*attack_damage -> 5*attack_damage, knockback distance 1 -> 0.1 to improve follow-up performance
+🟩[buff] cyclone combo finisher knockback distance 1 -> 0 to encourage follow-up punishing the opponent
+🟩[buff] plunge attack (Weight of Sin) knockback distance 1 -> 0 to encourage follow-up punishing the opponent
+🟩[buff] prayer incantation's sword thrust knockback type Normal -> Heavy, knockback distance 1 -> 0 to make opponent vulnerable to follow-up prayer attacks, making it a meaningful attack that doesn't knock opponents away from prayer range when they're in i-frames 
+🟦[rebalance] basic attack_damage: 10 + 4*sword_level -> 5 + 1*sword_level, knockback distance 1 -> 0.5 to improve follow-up performance
+🟦[rebalance] blood disc: path damage 25 + 5*sword_level -> 9.5 + 1.5*sword_level; explosion damage40 + 8*sword_level -> 15.2 + 2.4*sword_level, explosion knockback type Normal -> Heavy, damage type magic -> fire  (so that it does not share damage type with some OP magic prayers)
+🟦[rebalance] ruby blade projectiles damage 40 + 1*attack_damage -> 0 + 0.75*attack_damage, damage type physical -> lightning
+🟥[nerf] basic combo finisher damage 4*attack_damage -> 3*attack_damage, knockback type Heavy -> Normal to reduce recovery time of the opponent
+🟥[nerf] charged attack damage 4*attack_damage -> 2.5*attack_damage
+🟥[nerf] dash attack damage 4*attack_damage -> 2*attack_damage, knockback type Heavy -> Normal, knockback distance 1 -> 3 to give opponents a safe room after being caught by this low-risk, multi-purpose attack
+
+Prayers:
+🟩 [buff] Verdiales damage 18 -> 20, knockback distance 1 -> 2 to improve follow-up performance, damage type magic -> fire (so that it does not share damage type with some OP magic prayers)
+🟩 [buff] Tirana damage 10 -> 30 (how tf TGK designed such a low damage value LOL)
+🟦 [rebalance] Taranto damage 20 -> 12, knockback type Normal -> Heavy, knockback distance 1 -> 0 to increase chances of follow-up and highlight its stun abilities
+🟦 [rebalance] Lorquiana damage 90 -> 20, knockback distance 1 -> 0 to make this long-range attack less formidable, damage type magic -> lightning
+🟦[rebalance] Cantina Miriam strike damage 100 -> 40, spikes damage 40 -> 16, spikes physicial buff efficiency 100% -> 40%, Miriam strike knockback type Normal -> Heavy and knockback distance 1 -> 2
+🟦[rebalance] Aubade damage 180 -> 60, physical efficiency 100% -> 200%, knockback type Normal -> Heavy, knockback distance 1 -> 4.444
+🟥[nerf] Romance spell buff efficiency 100% -> 75%, knockback distance 1 -> 0
+🟥[nerf] Zarabanda damage 18 -> 15, knockback distance 1 -> 1.5 to make follow-ups harder after hitting opponent with the shields
+🟥 [nerf] Debla damage 55 -> 30, spell buff efficiency 100% -> 50%, 
+🟥[nerf] Solea attack damage increase 15 -> 10, removes amplification for existing attack damage buff 
+
+Beads:
+🟥[nerf] Token of Appreciation: removes amplification for existing attack damage buff
+🟥[nerf] Drop of Coagulated Ink: spell buff 100 -> 80%
+🟥[nerf] Dove Skull: physical damage reduction 10% -> 5%
+🟥[nerf] Ember of the Holy Cremation: physical damage reduction 15% -> 10%
+🟥[nerf] Silver Grape: physical damage reduction 20% -> 15%
+
+Sword Hearts:
+🟩 [buff] Heart of Saltpeter Blood: attack damage increase (when at low health) 8 -> 15
+🟩 [buff] Brilliant Heart of Dawn: physical damage reduction -100% -> -50%
+🟦[rebalance] Heart of Oils: removes percentage-based amplification for physical damage, attack damage increase 0 -> 10, physical damage reduction -100% -> -50%
+🟥[[nerf] Smoking Heart of Incense: spell buff 150% -> 120%, blood disc damage increase 75% -> 60%
+🟥[[nerf] Apodictic Heart of Mea Culpa: removes amplification for existing attack damage buff, attack damage increase 10 -> 3


### PR DESCRIPTION
added PVP balance stats for all attacks, prayers, and equipment related to PVP.
Temporary documented all changes involved in a text file, might convert it to MarkDown and put it in a more proper directory for future.